### PR TITLE
Fix order retention on failed execution

### DIFF
--- a/src/test/java/accounts/PortfolioTest.java
+++ b/src/test/java/accounts/PortfolioTest.java
@@ -44,4 +44,13 @@ public class PortfolioTest {
         assertEquals(10000.0, startingCash, 0.0001);
     }
 
+    @Test
+    public void testOrderRetainedWhenPriceMissing() {
+        portfolio.placeOrder(new Order("AAPL", resources.enums.OrderType.BUY, 1));
+        java.util.Map<String, engine.Bar> bars = new java.util.HashMap<>();
+        bars.put("MSFT", new engine.Bar(java.time.LocalDateTime.now(), 1, 1, 1, 1, 1));
+        portfolio.acceptBars(bars);
+        assertEquals(1, portfolio.getPendingOrders().size());
+    }
+
 }


### PR DESCRIPTION
## Summary
- ensure Portfolio retains pending orders when execution fails
- return boolean from `executeSingleOrder`
- test that orders persist if price data is missing

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683ff08766e0832cb64dc78391a48715